### PR TITLE
Update define API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,30 +65,34 @@ See also [API reference](https://pckerneis.github.io/musch/#/api-reference.md).
 
 <a name="define"></a>
 
-### define(name, [defaultValue]) ⇒ <code>\*</code>
-Define variable in the execution context with an optional default value.
-This won't have any effects if a value is already defined for `name`.
+### define(name, [defaultValue]) ⇒ <code>Array</code>
+Define a variable with an optional default value. Once defined, the variable can be accessed and changed with
+the returned getter and setter functions. The set value is persisted across executions.
 
 **Kind**: global function  
-**Returns**: <code>\*</code> - the named value  
+**Returns**: <code>Array</code> - A tuple with a getter and a setter  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>string</code> | The accessor name |
-| [defaultValue] | <code>\*</code> | A default value |
+| [defaultValue] | <code>\*</code> | An optional default value |
 
-<a name="set"></a>
+**Example**  
+```js
+const [getFoo, setFoo] = define('foo');
+setFoo('bar');
+getFoo(); // returns 'bar'
+```
+<a name="undefine"></a>
 
-### set(name, value)
-Define or overwrite variable in the execution context with the provided value.
-This won't have any effects if a value is already defined for `name`.
+### undefine(name)
+Delete a variable from the execution context.
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>string</code> | The accessor name |
-| value | <code>\*</code> | new value |
 
 <a name="clear"></a>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,30 +65,34 @@ See also [API reference](api-reference.md).
 
 <a name="define"></a>
 
-### define(name, [defaultValue]) ⇒ <code>\*</code>
-Define variable in the execution context with an optional default value.
-This won't have any effects if a value is already defined for `name`.
+### define(name, [defaultValue]) ⇒ <code>Array</code>
+Define a variable with an optional default value. Once defined, the variable can be accessed and changed with
+the returned getter and setter functions. The set value is persisted across executions.
 
 **Kind**: global function  
-**Returns**: <code>\*</code> - the named value  
+**Returns**: <code>Array</code> - A tuple with a getter and a setter  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>string</code> | The accessor name |
-| [defaultValue] | <code>\*</code> | A default value |
+| [defaultValue] | <code>\*</code> | An optional default value |
 
-<a name="set"></a>
+**Example**  
+```js
+const [getFoo, setFoo] = define('foo');
+setFoo('bar');
+getFoo(); // returns 'bar'
+```
+<a name="undefine"></a>
 
-### set(name, value)
-Define or overwrite variable in the execution context with the provided value.
-This won't have any effects if a value is already defined for `name`.
+### undefine(name)
+Delete a variable from the execution context.
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>string</code> | The accessor name |
-| value | <code>\*</code> | new value |
 
 <a name="clear"></a>
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,30 +2,34 @@
 
 <a name="define"></a>
 
-## define(name, [defaultValue]) ⇒ <code>\*</code>
-Define variable in the execution context with an optional default value.
-This won't have any effects if a value is already defined for `name`.
+## define(name, [defaultValue]) ⇒ <code>Array</code>
+Define a variable with an optional default value. Once defined, the variable can be accessed and changed with
+the returned getter and setter functions. The set value is persisted across executions.
 
 **Kind**: global function  
-**Returns**: <code>\*</code> - the named value  
+**Returns**: <code>Array</code> - A tuple with a getter and a setter  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>string</code> | The accessor name |
-| [defaultValue] | <code>\*</code> | A default value |
+| [defaultValue] | <code>\*</code> | An optional default value |
 
-<a name="set"></a>
+**Example**  
+```js
+const [getFoo, setFoo] = define('foo');
+setFoo('bar');
+getFoo(); // returns 'bar'
+```
+<a name="undefine"></a>
 
-## set(name, value)
-Define or overwrite variable in the execution context with the provided value.
-This won't have any effects if a value is already defined for `name`.
+## undefine(name)
+Delete a variable from the execution context.
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>string</code> | The accessor name |
-| value | <code>\*</code> | new value |
 
 <a name="clear"></a>
 

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -10,7 +10,7 @@ import {
   speed,
   wait,
 } from './api/api.scheduler.js';
-import { _env, setEnv, setLogLines, setMidiOutput } from './api/api.shared.js';
+import { setLogLines, setMidiOutput } from './api/api.shared.js';
 import {
   cc,
   channel,
@@ -22,7 +22,7 @@ import {
   unsolo,
 } from './api/api.midi.js';
 import { clear, fclear, flog, log } from './api/api.log.js';
-import { define, set } from './api/api.env.js';
+import { define } from './api/api.env.js';
 import { iter, pick, ring } from './api/api.utils.js';
 import { getNoteNumberConstants } from './api/api.notes.js';
 import { getPattern } from 'euclidean-rhythms';
@@ -70,7 +70,6 @@ function getApi() {
 
     define,
     def: define,
-    set,
 
     pick,
     _p: pick,
@@ -98,11 +97,5 @@ export function getApiContext(midiOutput, textOutputLines) {
   resetScopes();
   setMidiOutput(midiOutput);
   setLogLines(textOutputLines);
-
-  setEnv({
-    ..._env,
-    ...getApi(),
-  });
-
-  return _env;
+  return getApi();
 }

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -22,7 +22,7 @@ import {
   unsolo,
 } from './api/api.midi.js';
 import { clear, fclear, flog, log } from './api/api.log.js';
-import { define } from './api/api.env.js';
+import { define, undefine } from './api/api.env.js';
 import { iter, pick, ring } from './api/api.utils.js';
 import { getNoteNumberConstants } from './api/api.notes.js';
 import { getPattern } from 'euclidean-rhythms';
@@ -70,6 +70,8 @@ function getApi() {
 
     define,
     def: define,
+    undefine,
+    undef: undefine,
 
     pick,
     _p: pick,

--- a/src/modules/api/api.env.js
+++ b/src/modules/api/api.env.js
@@ -1,26 +1,27 @@
-import { _env } from './api.shared.js';
+import { _persistedContext } from './api.shared.js';
 
 /**
  * Define variable in the execution context with an optional default value.
- * This won't have any effects if a value is already defined for `name`.
+ * Returns a tuple with a getter and a setter for the variable.
  * @param {string} name - The accessor name
- * @param {*} [defaultValue] - A default value
- * @return {*} the named value
+ * @param {*} [defaultValue] - An optional default value
+ * @return {Array} A tuple with a getter and a setter
  */
 export function define(name, defaultValue) {
-  if (_env[name] === undefined) {
-    _env[name] = defaultValue;
+  if (!Object.hasOwn(_persistedContext, name)) {
+    _persistedContext[name] = defaultValue;
   }
 
-  return _env[name];
+  return [
+    () => _persistedContext[name],
+    (value) => (_persistedContext[name] = value),
+  ];
 }
 
 /**
- * Define or overwrite variable in the execution context with the provided value.
- * This won't have any effects if a value is already defined for `name`.
+ * Delete a variable from the execution context.
  * @param {string} name - The accessor name
- * @param {*} value - new value
  */
-export function set(name, value) {
-  _env[name] = value;
+export function undefine(name) {
+  delete _persistedContext[name];
 }

--- a/src/modules/api/api.env.js
+++ b/src/modules/api/api.env.js
@@ -1,8 +1,14 @@
 import { _persistedContext } from './api.shared.js';
 
 /**
- * Define variable in the execution context with an optional default value.
- * Returns a tuple with a getter and a setter for the variable.
+ * Define a variable with an optional default value. Once defined, the variable can be accessed and changed with
+ * the returned getter and setter functions. The set value is persisted across executions.
+ *
+ * @example
+ * const [getFoo, setFoo] = define('foo');
+ * setFoo('bar');
+ * getFoo(); // returns 'bar'
+ *
  * @param {string} name - The accessor name
  * @param {*} [defaultValue] - An optional default value
  * @return {Array} A tuple with a getter and a setter

--- a/src/modules/api/api.env.js
+++ b/src/modules/api/api.env.js
@@ -14,7 +14,7 @@ import { _persistedContext } from './api.shared.js';
  * @return {Array} A tuple with a getter and a setter
  */
 export function define(name, defaultValue) {
-  if (!Object.hasOwn(_persistedContext, name)) {
+  if (!Object.prototype.hasOwnProperty.call(_persistedContext, name)) {
     _persistedContext[name] = defaultValue;
   }
 

--- a/src/modules/api/api.env.test.js
+++ b/src/modules/api/api.env.test.js
@@ -1,24 +1,44 @@
-import { _env, setEnv } from './api.shared.js';
-import { define, set } from './api.env.js';
+import { setPersistedContext } from './api.shared.js';
+import { define, undefine } from './api.env.js';
 
 beforeEach(() => {
-  setEnv({});
+  setPersistedContext({});
 });
 
-test('def() adds to context', () => {
-  const variable = define('fortyTwo', 42);
-  expect(variable).toBe(42);
-  expect(_env.fortyTwo).toBe(42);
+test('define() returns a getter and a setter for a named value', () => {
+  const [get, set] = define('fortyTwo');
+  expect(get()).toBe(undefined);
+
+  expect(set('foo')).toBe('foo');
+  expect(get()).toBe('foo');
 });
 
-test('def() does not overwrite', () => {
-  define('fortyTwo', 42);
-  const variable = define('fortyTwo', 48);
-  expect(variable).toBe(42);
-  expect(_env.fortyTwo).toBe(42);
+test('define() sets a default value', () => {
+  const [get] = define('fortyTwo', 'foo');
+  expect(get()).toBe('foo');
 });
 
-test('set() overwrite variable', () => {
-  set('fortyTwo', 48);
-  expect(_env.fortyTwo).toBe(48);
+test('define() does not overwrite with the default value when called a second time', () => {
+  define('fortyTwo', 'foo');
+
+  const [get] = define('fortyTwo', 'bar');
+  expect(get()).toBe('foo');
+});
+
+test('define() provides handles to the same value', () => {
+  const [get1, set1] = define('fortyTwo', 'foo');
+  const [get2] = define('fortyTwo', 'bar');
+
+  expect(get1()).toBe(get2());
+  set1('baz');
+
+  expect(get1()).toBe('baz');
+  expect(get1()).toBe(get2());
+});
+
+test('undefine() deletes a named value', () => {
+  const [get] = define('fortyTwo', 'foo');
+
+  undefine('fortyTwo');
+  expect(get()).toBe(undefined);
 });

--- a/src/modules/api/api.log.test.js
+++ b/src/modules/api/api.log.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { setEnv } from './api.shared.js';
+import { setPersistedContext } from './api.shared.js';
 import { initScheduler, startScheduler } from '../cli/scheduler.js';
 import { getApiContext } from '../api.js';
 
@@ -21,7 +21,7 @@ beforeEach(() => {
 
   currentTime = 0;
   messages = [];
-  setEnv({});
+  setPersistedContext({});
   initScheduler();
   mockDateNow(4537);
 });

--- a/src/modules/api/api.midi.test.js
+++ b/src/modules/api/api.midi.test.js
@@ -6,7 +6,7 @@ import {
   resetMuteAndSolo,
 } from './api.midi.js';
 import { jest } from '@jest/globals';
-import { setEnv } from './api.shared.js';
+import { setPersistedContext } from './api.shared.js';
 import { resetNotesCurrentlyOnState } from '../cli/midi.js';
 
 let currentTime = 0;
@@ -31,7 +31,7 @@ beforeEach(() => {
   midiOutput = {
     send: jest.fn(),
   };
-  setEnv({});
+  setPersistedContext({});
   initScheduler();
   mockDateNow(4537);
   resetNotesCurrentlyOnState();

--- a/src/modules/api/api.scheduler.js
+++ b/src/modules/api/api.scheduler.js
@@ -8,7 +8,7 @@ import {
 import { getDefaultMidiChannel } from './api.midi.js';
 import { getCurrentScope, popScope, pushScope } from './api.scope.js';
 import { isFinitePositiveNumber } from '../utils.js';
-import { _env } from './api.shared.js';
+import { _persistedContext } from './api.shared.js';
 
 /**
  * Returns the execution time
@@ -95,7 +95,7 @@ function callAction(action, ...args) {
   if (typeof action === 'function') {
     action(...args);
   } else {
-    _env[action](...args);
+    _persistedContext[action](...args);
   }
 }
 

--- a/src/modules/api/api.scheduler.test.js
+++ b/src/modules/api/api.scheduler.test.js
@@ -1,7 +1,7 @@
 import { getApiContext } from '../api.js';
 import { initScheduler, startScheduler } from '../cli/scheduler.js';
 import { jest } from '@jest/globals';
-import {setPersistedContext} from './api.shared.js';
+import { setPersistedContext } from './api.shared.js';
 
 let currentTime = 0;
 let messages = [];

--- a/src/modules/api/api.scheduler.test.js
+++ b/src/modules/api/api.scheduler.test.js
@@ -1,7 +1,7 @@
 import { getApiContext } from '../api.js';
 import { initScheduler, startScheduler } from '../cli/scheduler.js';
 import { jest } from '@jest/globals';
-import { setPersistedContext } from './api.shared.js';
+import {setPersistedContext} from './api.shared.js';
 
 let currentTime = 0;
 let messages = [];
@@ -169,6 +169,7 @@ test('repeat() ignore invalid intervals', () => {
   [0, null, -5, 'hey'].forEach((interval) => {
     startScheduler([]);
     const action = jest.fn();
+    // @ts-ignore
     repeat(interval, action, 5);
     advanceTime(5000);
     expect(action).toBeCalledTimes(0);
@@ -203,6 +204,7 @@ test('speed() sets speed', () => {
 
 test('speed() should not set invalid speed', () => {
   const apiContext = getApiContext(null, messages);
+  // @ts-ignore
   expect(() => apiContext.speed('hello')).toThrow();
 });
 

--- a/src/modules/api/api.scheduler.test.js
+++ b/src/modules/api/api.scheduler.test.js
@@ -1,7 +1,7 @@
 import { getApiContext } from '../api.js';
 import { initScheduler, startScheduler } from '../cli/scheduler.js';
 import { jest } from '@jest/globals';
-import { setEnv } from './api.shared.js';
+import { setPersistedContext } from './api.shared.js';
 
 let currentTime = 0;
 let messages = [];
@@ -21,7 +21,7 @@ beforeEach(() => {
 
   currentTime = 0;
   messages = [];
-  setEnv({});
+  setPersistedContext({});
   initScheduler();
   mockDateNow(4537);
 });

--- a/src/modules/api/api.shared.js
+++ b/src/modules/api/api.shared.js
@@ -1,6 +1,6 @@
 export let _midiOutput;
 export let _logLines;
-export let _env;
+export let _persistedContext;
 
 export function setMidiOutput(output) {
   _midiOutput = output;
@@ -10,6 +10,6 @@ export function setLogLines(logLines) {
   _logLines = logLines;
 }
 
-export function setEnv(env) {
-  _env = env;
+export function setPersistedContext(env) {
+  _persistedContext = env;
 }


### PR DESCRIPTION
- define() returns a getter and a setter
- Add undefine()
- _env is renamed to _persistedContext
- Persisted context is not exposed in execution context anymore